### PR TITLE
feat: vet health cards (read-only view)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import { middleware } from "#middlewares/middlewares.js";
 import { authMiddleware } from "#middlewares/middlewares.js";
 import itemRouter from "#api/initial-example/itemRoutes.js";
 import adoptionApplicationsRouter from "#modules/adoptionApplications/adoptionApplications.routes.js";
+import healthCardsRouter from "#modules/healthCards/healthCards.routes.js";
 import petsRouter from "#modules/pets/pets.routes.js";
 import volunteersRouter from "#modules/volunteers/volunteers.routes.js";
 
@@ -23,6 +24,7 @@ app.use(
   adoptionApplicationsRouter,
 );
 app.use("/api/pets", petsRouter);
+app.use("/api/health-cards", healthCardsRouter);
 app.use("/api/volunteers", authMiddleware, volunteersRouter);
 
 app.get("/", middleware);

--- a/backend/src/modules/healthCards/healthCards.controller.ts
+++ b/backend/src/modules/healthCards/healthCards.controller.ts
@@ -1,0 +1,22 @@
+import type { Request, Response } from "express";
+import * as healthCardsService from "./healthCards.service.js";
+import { validatePetId } from "./healthCards.validation.js";
+
+const sendBadRequest = (res: Response, message: string) =>
+  res.status(400).json({ error: message });
+
+const sendServerError = (res: Response, message = "Internal server error.") =>
+  res.status(500).json({ error: message });
+
+export const listByPet = async (req: Request, res: Response) => {
+  try {
+    const petId = validatePetId(req.params.petId);
+    const entries = await healthCardsService.listByPet(petId);
+    return res.json(entries);
+  } catch (error) {
+    if (error instanceof Error) {
+      return sendBadRequest(res, error.message);
+    }
+    return sendServerError(res);
+  }
+};

--- a/backend/src/modules/healthCards/healthCards.routes.ts
+++ b/backend/src/modules/healthCards/healthCards.routes.ts
@@ -1,0 +1,13 @@
+import express from "express";
+import * as healthCardsController from "./healthCards.controller.js";
+import { authMiddleware } from "#middlewares/middlewares.js";
+
+const router = express.Router();
+
+router.get(
+  "/pets/:petId/entries",
+  authMiddleware,
+  healthCardsController.listByPet,
+);
+
+export default router;

--- a/backend/src/modules/healthCards/healthCards.service.ts
+++ b/backend/src/modules/healthCards/healthCards.service.ts
@@ -1,0 +1,25 @@
+import { supabase } from "#config/supabaseClient.js";
+import type { HealthCardEntryRow } from "./healthCards.types.js";
+
+// The `health_card_entries` table is not yet in the generated Database types
+// from @repo/types, so we use an untyped reference to the table. Types are
+// enforced manually via the row type defined in healthCards.types.ts.
+const table = () =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (supabase as any).from("health_card_entries");
+
+export const listByPet = async (
+  petId: number,
+): Promise<HealthCardEntryRow[]> => {
+  const { data, error } = await table()
+    .select("*")
+    .eq("pet_id", petId)
+    .order("treatment_date", { ascending: false })
+    .order("id", { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? []) as HealthCardEntryRow[];
+};

--- a/backend/src/modules/healthCards/healthCards.service.ts
+++ b/backend/src/modules/healthCards/healthCards.service.ts
@@ -1,17 +1,35 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { supabase } from "#config/supabaseClient.js";
 import type { HealthCardEntryRow } from "./healthCards.types.js";
 
-// The `health_card_entries` table is not yet in the generated Database types
-// from @repo/types, so we use an untyped reference to the table. Types are
-// enforced manually via the row type defined in healthCards.types.ts.
-const table = () =>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (supabase as any).from("health_card_entries");
+// The `health_card_entries` table is not yet in the generated `Database`
+// type from `@repo/types`. We define a local schema fragment and cast the
+// shared supabase client through it so all queries below are fully typed
+// without relying on `any`.
+interface HealthCardsSchema {
+  public: {
+    Tables: {
+      health_card_entries: {
+        Row: HealthCardEntryRow;
+        Insert: HealthCardEntryRow;
+        Update: Partial<HealthCardEntryRow>;
+        Relationships: [];
+      };
+    };
+    Views: Record<never, never>;
+    Functions: Record<never, never>;
+    Enums: Record<never, never>;
+    CompositeTypes: Record<never, never>;
+  };
+}
+
+const sb = supabase as unknown as SupabaseClient<HealthCardsSchema>;
 
 export const listByPet = async (
   petId: number,
 ): Promise<HealthCardEntryRow[]> => {
-  const { data, error } = await table()
+  const { data, error } = await sb
+    .from("health_card_entries")
     .select("*")
     .eq("pet_id", petId)
     .order("treatment_date", { ascending: false })
@@ -21,5 +39,5 @@ export const listByPet = async (
     throw new Error(error.message);
   }
 
-  return (data ?? []) as HealthCardEntryRow[];
+  return data ?? [];
 };

--- a/backend/src/modules/healthCards/healthCards.service.ts
+++ b/backend/src/modules/healthCards/healthCards.service.ts
@@ -39,5 +39,5 @@ export const listByPet = async (
     throw new Error(error.message);
   }
 
-  return data ?? [];
+  return data;
 };

--- a/backend/src/modules/healthCards/healthCards.types.ts
+++ b/backend/src/modules/healthCards/healthCards.types.ts
@@ -1,0 +1,24 @@
+export const HEALTH_CARD_ENTRY_TYPES = [
+  "illness",
+  "treatment",
+  "medication",
+  "vaccination",
+  "checkup",
+  "other",
+] as const;
+
+export type HealthCardEntryType = (typeof HEALTH_CARD_ENTRY_TYPES)[number];
+
+export type HealthCardEntryRow = {
+  id: number;
+  pet_id: number;
+  entry_type: HealthCardEntryType;
+  title: string;
+  description: string | null;
+  medication: string | null;
+  treatment_date: string;
+  vet_id: string | null;
+  vet_email: string | null;
+  created_at: string;
+  updated_at: string;
+};

--- a/backend/src/modules/healthCards/healthCards.types.ts
+++ b/backend/src/modules/healthCards/healthCards.types.ts
@@ -9,7 +9,7 @@ export const HEALTH_CARD_ENTRY_TYPES = [
 
 export type HealthCardEntryType = (typeof HEALTH_CARD_ENTRY_TYPES)[number];
 
-export type HealthCardEntryRow = {
+export interface HealthCardEntryRow {
   id: number;
   pet_id: number;
   entry_type: HealthCardEntryType;
@@ -21,4 +21,4 @@ export type HealthCardEntryRow = {
   vet_email: string | null;
   created_at: string;
   updated_at: string;
-};
+}

--- a/backend/src/modules/healthCards/healthCards.validation.ts
+++ b/backend/src/modules/healthCards/healthCards.validation.ts
@@ -1,0 +1,10 @@
+export const validatePetId = (id: unknown): number => {
+  if (typeof id !== "string" || !id.trim()) {
+    throw new Error("Parameter 'petId' is required.");
+  }
+  const n = Number(id);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error("Parameter 'petId' must be a positive integer.");
+  }
+  return n;
+};

--- a/backend/src/modules/healthCards/supabase-setup.sql
+++ b/backend/src/modules/healthCards/supabase-setup.sql
@@ -1,0 +1,31 @@
+-- Health Cards feature — Supabase setup
+-- Run this entire script in Supabase SQL Editor (Project → SQL Editor → New query).
+-- It is idempotent: safe to re-run.
+
+create table if not exists public.health_card_entries (
+  id bigserial primary key,
+  pet_id bigint not null references public.pets(id) on delete cascade,
+  entry_type text not null default 'other'
+    check (entry_type in ('illness', 'treatment', 'medication', 'vaccination', 'checkup', 'other')),
+  title text not null,
+  description text,
+  medication text,
+  treatment_date date not null default current_date,
+  vet_id uuid,
+  vet_email text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists health_card_entries_pet_id_idx
+  on public.health_card_entries (pet_id, treatment_date desc);
+
+-- Row Level Security. Backend uses service_role key which bypasses RLS,
+-- so this policy is defense-in-depth for any direct anon-key access.
+alter table public.health_card_entries enable row level security;
+
+drop policy if exists "health_card_entries read for authenticated" on public.health_card_entries;
+create policy "health_card_entries read for authenticated"
+  on public.health_card_entries for select
+  to authenticated
+  using (true);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   LifeBuoy,
   LogOut,
   PawPrint,
+  Stethoscope,
   Users,
 } from "lucide-react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
@@ -22,6 +23,9 @@ const Sidebar = () => {
   const isDashboardOverview = location.pathname === "/dashboard";
   const isDashboardAdoptions = location.pathname === "/dashboard/adoptions";
   const isDashboardVolunteers = location.pathname === "/dashboard/volunteers";
+  const isHealthCards = location.pathname.startsWith("/health-cards");
+  const isVet =
+    (session?.user?.user_metadata?.role as string | undefined) === "vet";
 
   async function handleSignOut() {
     await signOut();
@@ -84,6 +88,18 @@ const Sidebar = () => {
             <LifeBuoy className="size-4" />
             Support cases
           </Button>
+          {isVet && (
+            <Button
+              asChild
+              variant={isHealthCards ? "secondary" : "ghost"}
+              className="w-full justify-start gap-2"
+            >
+              <Link to="/health-cards">
+                <Stethoscope className="size-4" />
+                Health cards
+              </Link>
+            </Button>
+          )}
         </nav>
 
         <Separator />

--- a/frontend/src/modules/healthCards/api/healthCardsApi.ts
+++ b/frontend/src/modules/healthCards/api/healthCardsApi.ts
@@ -1,0 +1,44 @@
+import { supabase } from "@/lib/supabaseClient";
+import type { HealthCardEntry } from "../types/HealthCard";
+
+const getAuthHeaders = async (): Promise<Record<string, string>> => {
+  if (!supabase) {
+    throw new Error("Supabase client is not initialized");
+  }
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const token = session?.access_token;
+  if (!token) {
+    throw new Error("You must be signed in.");
+  }
+  return { Authorization: `Bearer ${token}` };
+};
+
+const readError = async (
+  response: Response,
+  fallback: string,
+): Promise<string> => {
+  try {
+    const data = await response.json();
+    if (typeof data?.error === "string") {
+      return data.error;
+    }
+  } catch {
+    // no JSON body
+  }
+  return `${fallback} (${response.status})`;
+};
+
+export const listHealthCardEntries = async (
+  petId: number,
+): Promise<HealthCardEntry[]> => {
+  const headers = await getAuthHeaders();
+  const response = await fetch(`/api/health-cards/pets/${petId}/entries`, {
+    headers,
+  });
+  if (!response.ok) {
+    throw new Error(await readError(response, "Failed to load health card"));
+  }
+  return response.json();
+};

--- a/frontend/src/modules/healthCards/components/HealthCardEntryList.tsx
+++ b/frontend/src/modules/healthCards/components/HealthCardEntryList.tsx
@@ -1,0 +1,63 @@
+import {
+  HEALTH_CARD_ENTRY_TYPE_LABELS,
+  type HealthCardEntry,
+} from "../types/HealthCard";
+
+type Props = {
+  entries: HealthCardEntry[];
+};
+
+const formatDate = (iso: string): string => {
+  try {
+    return new Date(iso).toLocaleDateString("en-GB", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+};
+
+export const HealthCardEntryList = ({ entries }: Props) => {
+  if (entries.length === 0) {
+    return (
+      <p className="hc-empty">No entries in this animal's health card yet.</p>
+    );
+  }
+
+  return (
+    <ul className="hc-entry-list">
+      {entries.map((entry) => (
+        <li key={entry.id} className="hc-entry">
+          <div className="hc-entry__head">
+            <span className="hc-entry__date">
+              {formatDate(entry.treatment_date)}
+            </span>
+            <span className="hc-entry__type">
+              {HEALTH_CARD_ENTRY_TYPE_LABELS[entry.entry_type]}
+            </span>
+          </div>
+
+          <h3 className="hc-entry__title">{entry.title}</h3>
+
+          {entry.medication && (
+            <p className="hc-entry__field">
+              <strong>Medication:</strong> {entry.medication}
+            </p>
+          )}
+
+          {entry.description && (
+            <p className="hc-entry__field hc-entry__description">
+              {entry.description}
+            </p>
+          )}
+
+          {entry.vet_email && (
+            <p className="hc-entry__meta">Recorded by: {entry.vet_email}</p>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/frontend/src/modules/healthCards/components/PatientCard.tsx
+++ b/frontend/src/modules/healthCards/components/PatientCard.tsx
@@ -1,0 +1,63 @@
+import type { Pet } from "@/modules/pets/types/Pets";
+
+type Props = {
+  pet: Pet;
+  onOpen: (petId: number) => void;
+};
+
+export const PatientCard = ({ pet, onOpen }: Props) => {
+  return (
+    <div
+      className="hp-pet-card hc-patient-card"
+      onClick={() => onOpen(pet.id)}
+      style={{ cursor: "pointer" }}
+    >
+      {pet.image_url ? (
+        <img
+          src={pet.image_url}
+          alt={pet.name}
+          className="w-full h-40 object-cover"
+        />
+      ) : (
+        <div className="w-full h-40 bg-gray-100 flex items-center justify-center text-gray-400 text-sm">
+          No photo
+        </div>
+      )}
+
+      <div className="hp-pet-card__header">
+        <div>
+          <h2 className="hp-pet-card__title">{pet.name}</h2>
+          <p className="hp-pet-card__subtitle">{pet.breed ?? "—"}</p>
+          <p className="hp-pet-card__subtitle" style={{ fontSize: "0.7rem" }}>
+            id: {pet.id}
+          </p>
+        </div>
+        <span
+          className={
+            pet.species === "dog"
+              ? "hp-badge hp-badge--info"
+              : "hp-badge hp-badge--success"
+          }
+        >
+          {pet.species === "dog"
+            ? "Dog"
+            : pet.species === "cat"
+              ? "Cat"
+              : pet.species}
+        </span>
+      </div>
+
+      <button
+        type="button"
+        className="hp-btn hp-btn--primary"
+        style={{ width: "100%" }}
+        onClick={(event) => {
+          event.stopPropagation();
+          onOpen(pet.id);
+        }}
+      >
+        Open health card
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/modules/healthCards/components/healthCards.css
+++ b/frontend/src/modules/healthCards/components/healthCards.css
@@ -1,0 +1,276 @@
+/* Health Cards module — scoped styles. Reuses `hp-*` design tokens from
+   HomePage.css and adds `hc-*` classes for the health card UI.
+   The `.hc-page-wrap` selector provides explicit colors for `hp-btn`
+   classes that otherwise rely on CSS variables only defined under
+   `.shelter-public` (set on the public pages). */
+
+.hc-page-wrap .hp-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+  border-radius: 10px;
+  border: none;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.hc-page-wrap .hp-btn--primary {
+  background: #059669;
+  color: #fff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.hc-page-wrap .hp-btn--primary:hover {
+  background: #047857;
+}
+
+.hc-page-wrap .hp-btn--secondary {
+  background: #ffffff;
+  color: #2563eb;
+  border: 1px solid #e4e4e7;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.hc-page-wrap .hp-btn--secondary:hover {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+}
+
+.hc-page {
+  max-width: var(--hp-max, 1100px);
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.hc-page__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.hc-page__title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--hp-heading, #0f172a);
+  margin: 0;
+}
+
+.hc-page__subtitle {
+  color: var(--hp-text-muted, #475569);
+  font-size: 0.95rem;
+  margin-top: 0.25rem;
+}
+
+.hc-search {
+  margin-bottom: 1.5rem;
+  max-width: 360px;
+}
+
+.hc-patient-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.hc-patient-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.hc-empty {
+  color: var(--hp-text-muted, #475569);
+  font-style: italic;
+  padding: 1rem 0;
+}
+
+.hc-section {
+  background: var(--hp-surface, #fff);
+  border: 1px solid var(--hp-border, #e2e8f0);
+  border-radius: var(--hp-radius-lg, 12px);
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: var(--hp-shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.04));
+}
+
+.hc-section__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--hp-heading, #0f172a);
+  margin: 0 0 0.75rem;
+}
+
+.hc-pet-summary {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hc-pet-summary__img {
+  width: 80px;
+  height: 80px;
+  border-radius: 12px;
+  object-fit: cover;
+}
+
+.hc-pet-summary__placeholder {
+  width: 80px;
+  height: 80px;
+  border-radius: 12px;
+  background: #f1f5f9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #94a3b8;
+  font-size: 0.75rem;
+}
+
+.hc-pet-summary__name {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.hc-pet-summary__meta {
+  font-size: 0.85rem;
+  color: var(--hp-text-muted, #475569);
+  margin: 0.25rem 0 0;
+}
+
+.hc-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.hc-form__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+@media (max-width: 600px) {
+  .hc-form__row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.hc-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.hc-form__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--hp-text, #1e293b);
+}
+
+.hc-form__textarea {
+  font-family: inherit;
+  resize: vertical;
+  min-height: 80px;
+}
+
+.hc-form__error {
+  color: #b91c1c;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.hc-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.hc-entry-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.hc-entry {
+  background: var(--hp-surface, #fff);
+  border: 1px solid var(--hp-border, #e2e8f0);
+  border-left: 4px solid var(--hp-blue, #2563eb);
+  border-radius: var(--hp-radius-lg, 12px);
+  padding: 1rem 1.25rem;
+}
+
+.hc-entry__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.hc-entry__date {
+  font-weight: 600;
+  color: var(--hp-heading, #0f172a);
+}
+
+.hc-entry__type {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: var(--hp-blue-soft, #dbeafe);
+  color: var(--hp-blue, #2563eb);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.hc-entry__title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 0.25rem 0 0.5rem;
+  color: var(--hp-heading, #0f172a);
+}
+
+.hc-entry__field {
+  margin: 0.25rem 0;
+  color: var(--hp-text, #1e293b);
+  font-size: 0.95rem;
+}
+
+.hc-entry__description {
+  white-space: pre-wrap;
+}
+
+.hc-entry__meta {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--hp-text-muted, #475569);
+}
+
+.hc-banner {
+  background: #fef3c7;
+  border: 1px solid #fde68a;
+  color: #92400e;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.hc-banner--error {
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}

--- a/frontend/src/modules/healthCards/hooks/useHealthCardEntries.ts
+++ b/frontend/src/modules/healthCards/hooks/useHealthCardEntries.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import type { HealthCardEntry } from "../types/HealthCard";
+import { listHealthCardEntries } from "../api/healthCardsApi";
+
+export const healthCardEntriesQueryKey = (petId: number) => [
+  "health_card_entries",
+  petId,
+];
+
+export const useHealthCardEntries = (
+  petId: number,
+  options?: { enabled?: boolean },
+) => {
+  return useQuery<HealthCardEntry[], Error>({
+    queryKey: healthCardEntriesQueryKey(petId),
+    queryFn: () => listHealthCardEntries(petId),
+    staleTime: 30 * 1000,
+    enabled: options?.enabled ?? (Number.isFinite(petId) && petId > 0),
+  });
+};

--- a/frontend/src/modules/healthCards/types/HealthCard.ts
+++ b/frontend/src/modules/healthCards/types/HealthCard.ts
@@ -1,0 +1,36 @@
+export const HEALTH_CARD_ENTRY_TYPES = [
+  "illness",
+  "treatment",
+  "medication",
+  "vaccination",
+  "checkup",
+  "other",
+] as const;
+
+export type HealthCardEntryType = (typeof HEALTH_CARD_ENTRY_TYPES)[number];
+
+export type HealthCardEntry = {
+  id: number;
+  pet_id: number;
+  entry_type: HealthCardEntryType;
+  title: string;
+  description: string | null;
+  medication: string | null;
+  treatment_date: string;
+  vet_id: string | null;
+  vet_email: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export const HEALTH_CARD_ENTRY_TYPE_LABELS: Record<
+  HealthCardEntryType,
+  string
+> = {
+  illness: "Illness",
+  treatment: "Treatment",
+  medication: "Medication",
+  vaccination: "Vaccination",
+  checkup: "Check-up",
+  other: "Other",
+};

--- a/frontend/src/modules/healthCards/types/HealthCard.ts
+++ b/frontend/src/modules/healthCards/types/HealthCard.ts
@@ -9,7 +9,7 @@ export const HEALTH_CARD_ENTRY_TYPES = [
 
 export type HealthCardEntryType = (typeof HEALTH_CARD_ENTRY_TYPES)[number];
 
-export type HealthCardEntry = {
+export interface HealthCardEntry {
   id: number;
   pet_id: number;
   entry_type: HealthCardEntryType;
@@ -21,7 +21,7 @@ export type HealthCardEntry = {
   vet_email: string | null;
   created_at: string;
   updated_at: string;
-};
+}
 
 export const HEALTH_CARD_ENTRY_TYPE_LABELS: Record<
   HealthCardEntryType,

--- a/frontend/src/pages/healthCards/HealthCardPage.tsx
+++ b/frontend/src/pages/healthCards/HealthCardPage.tsx
@@ -1,0 +1,102 @@
+import { Link, useParams } from "react-router-dom";
+
+import Sidebar from "@/components/Sidebar";
+import { Badge } from "@/components/ui/badge";
+import { usePet } from "@/modules/pets/hooks/usePet";
+import { HealthCardEntryList } from "@/modules/healthCards/components/HealthCardEntryList";
+import { useHealthCardEntries } from "@/modules/healthCards/hooks/useHealthCardEntries";
+import "@/modules/healthCards/components/healthCards.css";
+
+export function HealthCardPage() {
+  const params = useParams<{ petId: string }>();
+  const petId = Number(params.petId);
+  const isValidPetId = Number.isInteger(petId) && petId > 0;
+
+  const pet = usePet(petId, { enabled: isValidPetId });
+  const entries = useHealthCardEntries(petId, { enabled: isValidPetId });
+
+  if (!isValidPetId) {
+    return (
+      <main className="hc-page-wrap grid min-h-screen grid-cols-1 bg-slate-50 lg:grid-cols-[260px_1fr]">
+        <Sidebar />
+        <section className="p-5 lg:p-8">
+          <p className="hc-banner hc-banner--error">Invalid animal ID.</p>
+          <Link to="/health-cards" className="hp-btn hp-btn--secondary">
+            Back to list
+          </Link>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="hc-page-wrap grid min-h-screen grid-cols-1 bg-slate-50 lg:grid-cols-[260px_1fr]">
+      <Sidebar />
+      <section className="space-y-6 p-5 lg:p-8">
+        <header className="space-y-2">
+          <Badge>Health card</Badge>
+          <h1 className="text-3xl font-semibold tracking-tight text-slate-900">
+            {pet.data?.name ?? "Patient"}
+          </h1>
+          <Link
+            to="/health-cards"
+            className="text-sm text-blue-600 hover:underline"
+          >
+            ← Back to patients list
+          </Link>
+        </header>
+
+        {pet.isPending && <p className="hc-empty">Loading animal data…</p>}
+        {pet.error && (
+          <div className="hc-banner hc-banner--error">
+            Failed to load animal data: {pet.error.message}
+          </div>
+        )}
+
+        {pet.data && (
+          <section className="hc-section">
+            <div className="hc-pet-summary">
+              {pet.data.image_url ? (
+                <img
+                  src={pet.data.image_url}
+                  alt={pet.data.name}
+                  className="hc-pet-summary__img"
+                />
+              ) : (
+                <div className="hc-pet-summary__placeholder">no photo</div>
+              )}
+              <div>
+                <h2 className="hc-pet-summary__name">{pet.data.name}</h2>
+                <p className="hc-pet-summary__meta">
+                  {pet.data.species === "dog"
+                    ? "Dog"
+                    : pet.data.species === "cat"
+                      ? "Cat"
+                      : pet.data.species}
+                  {pet.data.breed ? ` • ${pet.data.breed}` : ""}
+                  {pet.data.age ? ` • ${pet.data.age} years` : ""}
+                  {pet.data.weight ? ` • ${pet.data.weight} kg` : ""}
+                </p>
+                <p className="hc-pet-summary__meta">id: {pet.data.id}</p>
+              </div>
+            </div>
+          </section>
+        )}
+
+        <section className="hc-section">
+          <h2 className="hc-section__title">Entry history</h2>
+
+          {entries.isPending && <p className="hc-empty">Loading entries…</p>}
+
+          {entries.error && (
+            <div className="hc-banner hc-banner--error">
+              {entries.error.message}
+            </div>
+          )}
+
+          {entries.data && <HealthCardEntryList entries={entries.data} />}
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/pages/healthCards/HealthCardsPatientsPage.tsx
+++ b/frontend/src/pages/healthCards/HealthCardsPatientsPage.tsx
@@ -1,0 +1,83 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import Sidebar from "@/components/Sidebar";
+import { Badge } from "@/components/ui/badge";
+import { usePetList } from "@/modules/pets/hooks/usePetList";
+import type { Pet } from "@/modules/pets/types/Pets";
+import { PatientCard } from "@/modules/healthCards/components/PatientCard";
+import "@/modules/healthCards/components/healthCards.css";
+import "@/pages/pets/PetsPage.css";
+
+export function HealthCardsPatientsPage() {
+  const { data, error, isPending } = usePetList();
+  const [search, setSearch] = useState("");
+  const navigate = useNavigate();
+
+  const filtered = useMemo<Pet[]>(() => {
+    const normalized = search.trim().toLowerCase();
+    if (!normalized) return data ?? [];
+    return (data ?? []).filter((pet) => {
+      const name = (pet.name ?? "").toLowerCase();
+      const breed = (pet.breed ?? "").toLowerCase();
+      const id = String(pet.id);
+      return (
+        name.includes(normalized) ||
+        breed.includes(normalized) ||
+        id.includes(normalized)
+      );
+    });
+  }, [data, search]);
+
+  return (
+    <main className="hc-page-wrap grid min-h-screen grid-cols-1 bg-slate-50 lg:grid-cols-[260px_1fr]">
+      <Sidebar />
+      <section className="space-y-6 p-5 lg:p-8">
+        <header className="space-y-2">
+          <Badge>Health cards</Badge>
+          <h1 className="text-3xl font-semibold tracking-tight text-slate-900">
+            Patients
+          </h1>
+          <p className="text-sm text-slate-600">
+            Select an animal to browse its digital health card: treatment
+            history, administered medications and past illnesses.
+          </p>
+        </header>
+
+        <div className="hc-search">
+          <input
+            type="search"
+            className="hp-input"
+            placeholder="Search by name, breed or ID..."
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+        </div>
+
+        {isPending && <p className="hc-empty">Loading patients…</p>}
+
+        {error && (
+          <div className="hc-banner hc-banner--error">
+            Failed to load patients: {error.message}
+          </div>
+        )}
+
+        {!isPending && !error && filtered.length === 0 && (
+          <p className="hc-empty">No patients match your search.</p>
+        )}
+
+        {!isPending && !error && filtered.length > 0 && (
+          <div className="hc-patient-grid">
+            {filtered.map((pet) => (
+              <PatientCard
+                key={pet.id}
+                pet={pet}
+                onOpen={(petId) => navigate(`/health-cards/${petId}`)}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -7,8 +7,11 @@ import { VolunteersDashboardPage } from "@/pages/dashboard/VolunteersDashboardPa
 import { HomePage } from "@/pages/public/HomePage";
 import { DashboardPage } from "@/pages/dashboard/DashboardPage";
 import { PetsPage } from "@/pages/pets/PetsPage";
+import { HealthCardsPatientsPage } from "@/pages/healthCards/HealthCardsPatientsPage";
+import { HealthCardPage } from "@/pages/healthCards/HealthCardPage";
 import { ProtectedRoute } from "@/routes/ProtectedRoute";
 import { CoordinatorRoute } from "@/routes/CoordinatorRoute";
+import { VetRoute } from "@/routes/VetRoute";
 
 export const AppRoutes = () => {
   return (
@@ -40,6 +43,22 @@ export const AppRoutes = () => {
           <CoordinatorRoute>
             <VolunteersDashboardPage />
           </CoordinatorRoute>
+        }
+      />
+      <Route
+        path="/health-cards"
+        element={
+          <VetRoute>
+            <HealthCardsPatientsPage />
+          </VetRoute>
+        }
+      />
+      <Route
+        path="/health-cards/:petId"
+        element={
+          <VetRoute>
+            <HealthCardPage />
+          </VetRoute>
         }
       />
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/routes/VetRoute.tsx
+++ b/frontend/src/routes/VetRoute.tsx
@@ -1,0 +1,37 @@
+import { useAuth } from "@/modules/auth/hooks/useAuth";
+import type { ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+
+type Props = {
+  children: ReactNode;
+};
+
+export function VetRoute({ children }: Props) {
+  const { session, isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 text-slate-600">
+        Loading...
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const role = session?.user?.user_metadata?.role as string | undefined;
+  if (role !== "vet") {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-2 bg-slate-50 p-6 text-center">
+        <h1 className="text-xl font-semibold text-slate-900">Access denied</h1>
+        <p className="text-sm text-slate-600">
+          This section is only available to vets.
+        </p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
Adds a vet-only "Health cards" section: a patients list (reusing the existing pet gallery data) and a per-pet health card page showing treatment history, medications and past illnesses (read-only).

Access is gated to users with `user_metadata.role === "vet"`. Creating and editing entries is intentionally out of scope and will be handled in a separate PR.

Requires running backend/src/modules/healthCards/supabase-setup.sql once to create the `health_card_entries` table.